### PR TITLE
Allow loading data provider callbacks from saved json 

### DIFF
--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -2986,7 +2986,30 @@ local function sendValueToStorage_thingspeak(watch_description,lul_device, lul_s
 	end
 	return 0
 end
-
+local function table_search (tt, v,stack,level)
+	local key, value
+	if level > 5 then
+		return nil
+	end
+	debug(string.format("table_search(v=%s,stack%s)",v,stack))
+	if type(tt) == "table" then
+		for key, value in pairs (tt) do
+			if key ~= v then
+				--debug(string.format("table_search: new table found , key=%s",key))
+				local r = table_search(value, v,stack.."-"..key,level+1 )
+				if r ~= nil then
+					return r
+				end
+			elseif key == v then
+				debug(string.format("table_search: found value! key=%s",key))
+				return value 
+			else
+			--debug(string.format("Searching for value %s, Ignoring value %s/%s",v,stack,key))
+			end
+		end
+	end
+	return nil
+end
 local function _loadDataProviders()
 	local str = luup.variable_get(ALTUI_SERVICE, "DataStorageProviders",  lul_device) or "{}"
 	debug(string.format("_loadDataProvider()->%s",str) )
@@ -3156,30 +3179,6 @@ function _evaluateUserExpression(lul_device, devid, lul_service, lul_variable,ol
 		end
 	end
 	return results
-end
-local function table_search (tt, v,stack,level)
-	local key, value
-	if level > 5 then
-		return nil
-	end
-	debug(string.format("table_search(v=%s,stack%s)",v,stack))
-	if type(tt) == "table" then
-		for key, value in pairs (tt) do
-			if key ~= v then
-				--debug(string.format("table_search: new table found , key=%s",key))
-				local r = table_search(value, v,stack.."-"..key,level+1 )
-				if r ~= nil then
-					return r
-				end
-			elseif key == v then
-				debug(string.format("table_search: found value! key=%s",key))
-				return value 
-			else
-			--debug(string.format("Searching for value %s, Ignoring value %s/%s",v,stack,key))
-			end
-		end
-	end
-	return nil
 end
 
 

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3159,8 +3159,8 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 						warning(string.format("sendValuetoUrlStorage() failed"))
 					end
 				else
-					debug(string.format("sendValueToStorage: Requires a callback ")
-					local callback_fn = DataProvidersCallbacks[DataProviders[provider]["callback"]];
+					debug(string.format("sendValueToStorage: Requires a callback "))
+					local callback_fn = DataProvidersCallbacks[DataProviders[provider]["callback"]]
 					if(callback_fn==nil)
 						-- Assume that the callback function is valid
 						callback_fn = DataProviders[provider]["callback"];

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -2990,6 +2990,14 @@ end
 local function _loadDataProviders()
 	local str = luup.variable_get(ALTUI_SERVICE, "DataStorageProviders",  lul_device) or "{}"
 	DataProviders = json.decode(str)
+	for k,v in pairs (DataProviders) do
+		if (v["callback"] ~= nil) 
+			local callback_fn = table_search(_G,DataProviders[provider]["callback"],"",0)
+			if callback_fn ~= nil then
+				DataProvidersCallbacks[DataProviders[provider]["callback"]] = callback_fn
+			end			
+		end
+	end
 end
 
 local function _saveDataProvider() 
@@ -3186,15 +3194,6 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 				else
 					debug(string.format("sendValueToStorage: Requires a callback "))
 					local callback_fn = DataProvidersCallbacks[DataProviders[provider]["callback"]]
-					if(callback_fn==nil) then 
-						-- Assume that the callback function is valid and try to get it from the global table
-						warning(string.format("sendValueToStorage: using function name %s as callback for %s",DataProviders[provider]["callback"],provider))
-						callback_fn = table_search(_G,DataProviders[provider]["callback"],"",0)
-						if callback_fn ~= nil then
-							-- save this to speed up execution next time
-							DataProvidersCallbacks[DataProviders[provider]["callback"]] = callback_fn
-						end
-					end
 					if(callback_fn~=nil) then 
 						(callback_fn)(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])
 					else

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3151,12 +3151,12 @@ local function table_search (tt, v,stack,level)
 	if level > 5 then
 		return nil
 	end
-	--debug(string.format("table_search(v=%s,stack%s)",v,stack))
+	debug(string.format("table_search(v=%s,stack%s)",v,stack))
 	if type(tt) == "table" then
 		for key, value in pairs (tt) do
 			if key ~= v then
 				--debug(string.format("table_search: new table found , key=%s",key))
-				local r = table_search(value, v,stack .. key,level+1 )
+				local r = table_search(value, v,stack.."-"..key,level+1 )
 				if r ~= nil then
 					return r
 				end

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -2992,10 +2992,11 @@ local function _loadDataProviders()
 	debug(string.format("_loadDataProvider()->%s",str) )
 	DataProviders = json.decode(str)
 	for k,v in pairs (DataProviders) do
-		debug(string.format("_loadDataProvider() , DataStorageProviders:%s=%s",k,json.encode(v)))
 		if (v["callback"] ~= nil) then
+			debug(string.format("_loadDataProvider(), callback->%s",v["callback"]))
 			local callback_fn = table_search(_G,DataProviders[provider]["callback"],"",0)
 			if callback_fn ~= nil then
+				debug(string.format("_loadDataProvider(), callback->%s found function",v["callback"]))
 				DataProvidersCallbacks[DataProviders[provider]["callback"]] = callback_fn
 			end			
 		end

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3159,7 +3159,16 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 						warning(string.format("sendValuetoUrlStorage() failed"))
 					end
 				else
-					(DataProvidersCallbacks[DataProviders[provider]["callback"]])(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])
+					local callback_fn = DataProvidersCallbacks[DataProviders[provider]["callback"]];
+					if(callback_fn==nil)
+						-- Assume that the callback function is valid
+						callback_fn = DataProviders[provider]["callback"];
+					end
+					if(callback_fn~=nil)
+						(callback_fn)(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])
+					else
+						warning(string.format("sendValueToStorage - callback and url missing for provider:%s",provider))
+					end
 				end
 			else
 				warning(string.format("sendValueToStorage - unknown provider:%s",provider))

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3159,7 +3159,7 @@ local function table_search (tt, v,stack,level)
 	if level > 5 then
 		return nil
 	end
-	--debug(string.format("table_search(v=%s,stack%s)",v,stack))
+	debug(string.format("table_search(v=%s,stack%s)",v,stack))
 	if type(tt) == "table" then
 		for key, value in pairs (tt) do
 			if key ~= v then

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -2989,6 +2989,7 @@ end
 
 local function _loadDataProviders()
 	local str = luup.variable_get(ALTUI_SERVICE, "DataStorageProviders",  lul_device) or "{}"
+	debug(string.format("_loadDataProvider()->%s",str) )
 	DataProviders = json.decode(str)
 	for k,v in pairs (DataProviders) do
 		debug(string.format("_loadDataProvider() , DataStorageProviders:%s",json.encode(DataProviders)))

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3146,21 +3146,18 @@ function _evaluateUserExpression(lul_device, devid, lul_service, lul_variable,ol
 	end
 	return results
 end
-local function table_search (tt, v)
-	return table_search (tt, v,"")
-end
 local function table_search (tt, v,stack)
   if type(tt) == "table" then
     for key, value in pairs (tt) do
-      if type (value) == "table" then
-        local r = table_search(value, v,stack .. key ))
+      if v ~= key then
+        local r = table_search(value, v,stack .. key )
 	if r ~= nil then
 		return r
 	end
       elseif v == key then
 	return value 
       else
-        debug(string.format("Searching for value %s, Ignoring value %s/%s"),v,stack,key)
+        debug(string.format("Searching for value %s, Ignoring value %s/%s",v,stack,key))
       end
     end
   end
@@ -3185,7 +3182,7 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 					if(callback_fn==nil) then 
 						-- Assume that the callback function is valid and try to get it from the global table
 						warning(string.format("sendValueToStorage: using function name %s as callback for %s",DataProviders[provider]["callback"],provider))
-						callback_fn = table_search(_G,DataProviders[provider]["callback"])
+						callback_fn = table_search(_G,DataProviders[provider]["callback"],"")
 					end
 					if(callback_fn~=nil) then 
 						(callback_fn)(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3163,7 +3163,8 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 					local callback_fn = DataProvidersCallbacks[DataProviders[provider]["callback"]]
 					if(callback_fn==nil) then 
 						-- Assume that the callback function is valid
-						callback_fn = DataProviders[provider]["callback"]
+						callback_fn = _G[DataProviders[provider]["callback"]]
+						
 						warning(string.format("sendValueToStorage: using function name %s as callback for %s",callback_fn,provider))
 					end
 					if(callback_fn~=nil) then 

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3146,15 +3146,18 @@ function _evaluateUserExpression(lul_device, devid, lul_service, lul_variable,ol
 	end
 	return results
 end
-local function table_search (tt, v,stack)
+local function table_search (tt, v,stack,level)
 	local key, value
+	if level > 5
+		return nil
+	end
 	debug(string.format("table_search(v=%s,stack%s)",v,stack))
   if type(tt) == "table" then
     
     for key, value in pairs (tt) do
       if key ~= v then
 	--debug(string.format("table_search: new table found , key=%s",key))
-        local r = table_search(value, v,stack .. key )
+        local r = table_search(value, v,stack .. key,level+1 )
 	if r ~= nil then
 		return r
 	end
@@ -3188,7 +3191,7 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 					if(callback_fn==nil) then 
 						-- Assume that the callback function is valid and try to get it from the global table
 						warning(string.format("sendValueToStorage: using function name %s as callback for %s",DataProviders[provider]["callback"],provider))
-						callback_fn = table_search(_G,DataProviders[provider]["callback"],"")
+						callback_fn = table_search(_G,DataProviders[provider]["callback"],"",0)
 						if callback_fn ~= nil then
 							-- save this to speed up execution next time
 							DataProvidersCallbacks[DataProviders[provider]["callback"]] = callback_fn

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3171,8 +3171,7 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 					else
 						warning(string.format("sendValueToStorage: callback and url missing for provider:%s",provider))
 						for n,v in pairs(_G) do
-								debug(n,v)
-								end
+							debug(n,v)
 						end						
 						
 					end

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3151,26 +3151,24 @@ local function table_search (tt, v,stack,level)
 	if level > 5 then
 		return nil
 	end
-	debug(string.format("table_search(v=%s,stack%s)",v,stack))
-  if type(tt) == "table" then
-    
-    for key, value in pairs (tt) do
-      if key ~= v then
-	--debug(string.format("table_search: new table found , key=%s",key))
-        local r = table_search(value, v,stack .. key,level+1 )
-	if r ~= nil then
-		return r
+	--debug(string.format("table_search(v=%s,stack%s)",v,stack))
+	if type(tt) == "table" then
+		for key, value in pairs (tt) do
+			if key ~= v then
+				--debug(string.format("table_search: new table found , key=%s",key))
+				local r = table_search(value, v,stack .. key,level+1 )
+				if r ~= nil then
+					return r
+				end
+			elseif key == v then
+				--debug(string.format("table_search: found value! key=%s",key))
+				return value 
+			else
+			--debug(string.format("Searching for value %s, Ignoring value %s/%s",v,stack,key))
+			end
+		end
 	end
-      elseif key == v then
-	debug(string.format("table_search: found value! key=%s",key))
-				
-	return value 
-      else
-        --debug(string.format("Searching for value %s, Ignoring value %s/%s",v,stack,key))
-      end
-    end
-  end
-  return nil
+	return nil
 end
 
 

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3151,7 +3151,7 @@ local function table_search (tt, v,stack,level)
 	if level > 5 then
 		return nil
 	end
-	debug(string.format("table_search(v=%s,stack%s)",v,stack))
+	--debug(string.format("table_search(v=%s,stack%s)",v,stack))
 	if type(tt) == "table" then
 		for key, value in pairs (tt) do
 			if key ~= v then
@@ -3161,7 +3161,7 @@ local function table_search (tt, v,stack,level)
 					return r
 				end
 			elseif key == v then
-				--debug(string.format("table_search: found value! key=%s",key))
+				debug(string.format("table_search: found value! key=%s",key))
 				return value 
 			else
 			--debug(string.format("Searching for value %s, Ignoring value %s/%s",v,stack,key))

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3159,15 +3159,17 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 						warning(string.format("sendValuetoUrlStorage() failed"))
 					end
 				else
+					debug(string.format("sendValueToStorage: Requires a callback ")
 					local callback_fn = DataProvidersCallbacks[DataProviders[provider]["callback"]];
 					if(callback_fn==nil)
 						-- Assume that the callback function is valid
 						callback_fn = DataProviders[provider]["callback"];
+						warning(string.format("sendValueToStorage: using function name %s as callback for %s",callback_fn,provider))
 					end
 					if(callback_fn~=nil)
 						(callback_fn)(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])
 					else
-						warning(string.format("sendValueToStorage - callback and url missing for provider:%s",provider))
+						warning(string.format("sendValueToStorage: callback and url missing for provider:%s",provider))
 					end
 				end
 			else

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3161,12 +3161,12 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 				else
 					debug(string.format("sendValueToStorage: Requires a callback "))
 					local callback_fn = DataProvidersCallbacks[DataProviders[provider]["callback"]]
-					if(callback_fn==nil)  then 
+					if(callback_fn==nil) then 
 						-- Assume that the callback function is valid
-						callback_fn = DataProviders[provider]["callback"];
+						callback_fn = DataProviders[provider]["callback"]
 						warning(string.format("sendValueToStorage: using function name %s as callback for %s",callback_fn,provider))
 					end
-					if(callback_fn~=nil)  then 
+					if(callback_fn~=nil) then 
 						(callback_fn)(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])
 					else
 						warning(string.format("sendValueToStorage: callback and url missing for provider:%s",provider))

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3161,12 +3161,12 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 				else
 					debug(string.format("sendValueToStorage: Requires a callback "))
 					local callback_fn = DataProvidersCallbacks[DataProviders[provider]["callback"]]
-					if(callback_fn==nil)
+					if(callback_fn==nil)  then 
 						-- Assume that the callback function is valid
 						callback_fn = DataProviders[provider]["callback"];
 						warning(string.format("sendValueToStorage: using function name %s as callback for %s",callback_fn,provider))
 					end
-					if(callback_fn~=nil)
+					if(callback_fn~=nil)  then 
 						(callback_fn)(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])
 					else
 						warning(string.format("sendValueToStorage: callback and url missing for provider:%s",provider))
@@ -3364,7 +3364,7 @@ function _delWatch(service, variable, deviceid, sceneid, expression, xml, provid
 			-- watch for scene
 			local n = tablelength(registeredWatches[devidstr][service][variable]['Expressions'][expression])
 			for i=n,1,-1 do
-				if (registeredWatches[devidstr][service][variable]['Expressions'][expression][i]["SceneID"] == sceneid) then
+				if (registeredWatches[devidstr][service][variable]['Expressions'][expression][i]["SceneID"] == sceneid) then 
 					table.remove(registeredWatches[devidstr][service][variable]['Expressions'][expression], i)
 					removed = removed +1
 				end

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3147,14 +3147,19 @@ function _evaluateUserExpression(lul_device, devid, lul_service, lul_variable,ol
 	return results
 end
 local function table_search (tt, v,stack)
+	local key, value
+	debug(string.format("table_search(v=%s,stack%s)",v,stack))
   if type(tt) == "table" then
+    
     for key, value in pairs (tt) do
-      if v ~= key then
+      if key ~= v then
+	debug(string.format("table_search: new table found , key=%s",key))
         local r = table_search(value, v,stack .. key )
 	if r ~= nil then
 		return r
 	end
-      elseif v == key then
+      elseif key == v then
+	debug(string.format("table_search: found value! key=%s",key))
 	return value 
       else
         debug(string.format("Searching for value %s, Ignoring value %s/%s",v,stack,key))

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3148,7 +3148,7 @@ function _evaluateUserExpression(lul_device, devid, lul_service, lul_variable,ol
 end
 local function table_search (tt, v,stack,level)
 	local key, value
-	if level > 5
+	if level > 5 then
 		return nil
 	end
 	debug(string.format("table_search(v=%s,stack%s)",v,stack))

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -2992,7 +2992,7 @@ local function _loadDataProviders()
 	debug(string.format("_loadDataProvider()->%s",str) )
 	DataProviders = json.decode(str)
 	for k,v in pairs (DataProviders) do
-		debug(string.format("_loadDataProvider() , DataStorageProviders:%s",json.encode(DataProviders)))
+		debug(string.format("_loadDataProvider() , DataStorageProviders:%s=%s",k,json.encode(v)))
 		if (v["callback"] ~= nil) then
 			local callback_fn = table_search(_G,DataProviders[provider]["callback"],"",0)
 			if callback_fn ~= nil then

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -2991,7 +2991,7 @@ local function _loadDataProviders()
 	local str = luup.variable_get(ALTUI_SERVICE, "DataStorageProviders",  lul_device) or "{}"
 	DataProviders = json.decode(str)
 	for k,v in pairs (DataProviders) do
-		if (v["callback"] ~= nil) 
+		if (v["callback"] ~= nil) then
 			local callback_fn = table_search(_G,DataProviders[provider]["callback"],"",0)
 			if callback_fn ~= nil then
 				DataProvidersCallbacks[DataProviders[provider]["callback"]] = callback_fn

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3162,10 +3162,9 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 					debug(string.format("sendValueToStorage: Requires a callback "))
 					local callback_fn = DataProvidersCallbacks[DataProviders[provider]["callback"]]
 					if(callback_fn==nil) then 
-						-- Assume that the callback function is valid
+						-- Assume that the callback function is valid and try to get it from the global table
+						warning(string.format("sendValueToStorage: using function name %s as callback for %s",DataProviders[provider]["callback"],provider))
 						callback_fn = _G[DataProviders[provider]["callback"]]
-						
-						warning(string.format("sendValueToStorage: using function name %s as callback for %s",callback_fn,provider))
 					end
 					if(callback_fn~=nil) then 
 						(callback_fn)(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -2991,6 +2991,7 @@ local function _loadDataProviders()
 	local str = luup.variable_get(ALTUI_SERVICE, "DataStorageProviders",  lul_device) or "{}"
 	DataProviders = json.decode(str)
 	for k,v in pairs (DataProviders) do
+		debug(string.format("_loadDataProvider() , DataStorageProviders:%s",json.encode(DataProviders)))
 		if (v["callback"] ~= nil) then
 			local callback_fn = table_search(_G,DataProviders[provider]["callback"],"",0)
 			if callback_fn ~= nil then

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -2994,10 +2994,10 @@ local function _loadDataProviders()
 	for k,v in pairs (DataProviders) do
 		if (v["callback"] ~= nil) then
 			debug(string.format("_loadDataProvider(), callback->%s",v["callback"]))
-			local callback_fn = table_search(_G,DataProviders[provider]["callback"],"",0)
+			local callback_fn = table_search(_G,v["callback"],"",0)
 			if callback_fn ~= nil then
 				debug(string.format("_loadDataProvider(), callback->%s found function",v["callback"]))
-				DataProvidersCallbacks[DataProviders[provider]["callback"]] = callback_fn
+				DataProvidersCallbacks[v["callback"]] = callback_fn
 			end			
 		end
 	end

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3170,6 +3170,11 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 						(callback_fn)(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])
 					else
 						warning(string.format("sendValueToStorage: callback and url missing for provider:%s",provider))
+						for n,v in pairs(_G) do
+								debug(n,v)
+								end
+						end						
+						
 					end
 				end
 			else

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3153,16 +3153,17 @@ local function table_search (tt, v,stack)
     
     for key, value in pairs (tt) do
       if key ~= v then
-	debug(string.format("table_search: new table found , key=%s",key))
+	--debug(string.format("table_search: new table found , key=%s",key))
         local r = table_search(value, v,stack .. key )
 	if r ~= nil then
 		return r
 	end
       elseif key == v then
 	debug(string.format("table_search: found value! key=%s",key))
+				
 	return value 
       else
-        debug(string.format("Searching for value %s, Ignoring value %s/%s",v,stack,key))
+        --debug(string.format("Searching for value %s, Ignoring value %s/%s",v,stack,key))
       end
     end
   end
@@ -3188,6 +3189,10 @@ function sendValueToStorage(watch,lul_device, lul_service, lul_variable,old, new
 						-- Assume that the callback function is valid and try to get it from the global table
 						warning(string.format("sendValueToStorage: using function name %s as callback for %s",DataProviders[provider]["callback"],provider))
 						callback_fn = table_search(_G,DataProviders[provider]["callback"],"")
+						if callback_fn ~= nil then
+							-- save this to speed up execution next time
+							DataProvidersCallbacks[DataProviders[provider]["callback"]] = callback_fn
+						end
 					end
 					if(callback_fn~=nil) then 
 						(callback_fn)(v[i],lul_device, lul_service, lul_variable,old, new, lastupdate,DataProviders[provider]["parameters"])


### PR DESCRIPTION
Changed _loadDataProvider so that it binds functions to the callback table from a function name.

For example, in openLuup, functions declared in lua startup are found under the following structure
_`_G-package-loaded-openLuup.loader-shared_environment`_

This allows defining function driven data providers from the lua startup script and configuring them separately within the altui's settings. 