### PR TITLE
GCal3, power visual updates

### DIFF
--- a/J_ALTUI_plugins.js
+++ b/J_ALTUI_plugins.js
@@ -921,6 +921,16 @@ var ALTUI_PluginDisplays= ( function( window, undefined ) {
 		return _drawMotion( device);
 	};
 
+	function _drawGCal3( device) {
+		var html ="";
+		$.each( ['gc_NextEvent','gc_NextEventTime'],function(i,v) {
+			var dl1 = MultiBox.getStatus( device, 'urn:srs-com:serviceId:GCalIII', v );
+			if (dl1 != null)
+				html += $("<div class='altui-vswitch-text'></div>").text(dl1).wrap( "<div></div>" ).parent().html()
+		});
+		return html;
+	}
+
 	function _drawCombinationSwitch( device ) {
 		var html = "";
 
@@ -1923,6 +1933,7 @@ var ALTUI_PluginDisplays= ( function( window, undefined ) {
 	drawKeypadControlPanel : _drawKeypadControlPanel,
 	drawMotion	   : _drawMotion,
 	drawGCal	   : _drawGCal,
+	drawGCal3	   : _drawGCal3,
 	drawCombinationSwitch	: _drawCombinationSwitch,
 	drawHouseMode: _drawHouseMode,
 	drawDayTime		: _drawDayTime,

--- a/J_ALTUI_uimgr.js
+++ b/J_ALTUI_uimgr.js
@@ -702,6 +702,14 @@ var styles =`
 		position: absolute;
 		right: 0px;
 	}
+	.altui-favorites-kwh {
+		float: left;
+		text-align: left;
+		font-size: 14px;
+		bottom: 0px;
+		position: absolute;
+		left: 0px;
+	}
 	.btn.altui-housemode{
 		padding-left: 0px;
 		padding-right: 0px;
@@ -4548,7 +4556,11 @@ var UIManager  = ( function( window, undefined ) {
 		html += "<div class='{1}' data-altuiid='{0}'><div>".format(device.altuiid,cls);
 		var watts = parseFloat(MultiBox.getStatus( device, 'urn:micasaverde-com:serviceId:EnergyMetering1', 'Watts' ));
 		if (isNaN(watts)==false)
-			html += "<div class='bg-danger altui-favorites-watts'>{0} W</div>".format( Math.round(watts*10)/10 );
+			if (watts > 0) {
+				html += "<div class='bg-danger altui-favorites-watts'>{0} W</div>".format( Math.round(watts*10)/10 );
+			} else {
+				html += "<div class='bg-success altui-favorites-watts'>{0} W</div>".format( Math.round(watts*10)/10 );
+			}
 		switch(device.device_type) {
 			case "urn:schemas-micasaverde-com:device:BarometerSensor:1":
 			case "urn:schemas-micasaverde-com:device:WindSensor:1":
@@ -4620,6 +4632,16 @@ var UIManager  = ( function( window, undefined ) {
 				var watts = MultiBox.getStatus( device, 'urn:micasaverde-com:serviceId:EnergyMetering1', 'Watts' );
 				watts = Math.round(parseFloat(watts)*10)/10
 				html += "<span>{0}</span> <span class='altui-favorites-mediumtext'>W</span>".format(watts || "-");
+				break;
+			case "urn:schemas-smartmeter-han:device:SmartMeterHAN1:1":
+				var kwh = parseFloat(MultiBox.getStatus( device, 'urn:micasaverde-com:serviceId:EnergyMetering1', 'KWH' ));
+				if (isNaN(kwh)==false)
+					if (kwh > 0) {
+						html += "<div class='bg-danger altui-favorites-kwh'>{0} kWh</div>".format( Math.round(kwh*10)/10 );
+					} else {
+						html += "<div class='bg-success altui-favorites-kwh'>{0} kWh</div>".format( Math.round(kwh*10)/10 );
+					}
+				html += _drawDefaultFavoriteDevice(device);
 				break;
 			default:
 				var _altuitypesDB = MultiBox.getALTUITypesDB();	// Master controller

--- a/L_ALTUI.lua
+++ b/L_ALTUI.lua
@@ -3038,6 +3038,10 @@ local function getDefaultConfig()
 		["ScriptFile"]="J_ALTUI_plugins.js",
 		["DeviceDrawFunc"]="ALTUI_PluginDisplays.drawGCal"
 	}
+	tbl["urn:schemas-srs-com:device:GCal:3"]= {
+		["ScriptFile"]="J_ALTUI_plugins.js",
+		["DeviceDrawFunc"]="ALTUI_PluginDisplays.drawGCal3"
+	}
 	tbl["urn:schemas-futzle-com:device:CombinationSwitch:1"]= {
 		["ScriptFile"]="J_ALTUI_plugins.js",
 		["DeviceDrawFunc"]="ALTUI_PluginDisplays.drawCombinationSwitch"


### PR DESCRIPTION
3 Proposed changes:

1) GCal3: add gc_NextEvent and gc_NextEventTime to the devices display
2) Favorites: if power is negative (generating power) then make background green (success) instead of red (danger)
3) Rainforest Eagle plugin (SmartMeterHAN1): add energy (KWH) to lower left of favorite display